### PR TITLE
Allows saving the log locally for both failed and successful runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,18 @@ An example:
 	+ cp -rp data2 /backup
 	cp: data2: Permission denied
 
+### Saving output
+
+If you set the variable `CRONIC_RUN_LOG` to a local file name, the output is also written to the file, both in case
+of failure _and_ successful runs. That way you can refer back to the last execution, or see the errors if the mail
+got lost or not delivered.
+
+For example:
+
+	0 1 * * * CRONIC_RUN_LOG=/var/log/backup.log cronic backup
+
 ### Version History
+* v4 - Allows sending successful last run to a local file (in case you want to know what happened last)
 * v3 - Use mktemp-d to avoid race-conditions and security problems.
 * v2 - Corrected command evaluation, so shell meta-chars are preserved correctly (Thanks to Frank Wallingford for the fix).
 * v1 - Initial release.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ broken, it isn't cron. The only solution left is a work-around.
 
 ## The Cure: Cronic
 
-Download: [cronic](http://habilis.net/cronic/cronic) v3
+Download: [cronic](http://habilis.net/cronic/cronic) v4
 
 Cronic is a small shim shell script for wrapping cron jobs so that cron only sends email
 when an error has occurred. Cronic defines an error as any non-trace error output or a

--- a/cronic
+++ b/cronic
@@ -10,6 +10,7 @@ TMP=$(mktemp -d)
 OUT=$TMP/cronic.out
 ERR=$TMP/cronic.err
 TRACE=$TMP/cronic.trace
+CRONIC_RUN_LOG=${CRONIC_RUN_LOG:-}
 
 set +e
 "$@" >$OUT 2>$TRACE

--- a/cronic
+++ b/cronic
@@ -24,9 +24,7 @@ else
     ERR=$TRACE
 fi
 
-if [ $RESULT -ne 0 -o -s "$ERR" ]
-    then
-    echo "Cronic detected failure or error output for the command:"
+results() {
     echo "$@"
     echo
     echo "RESULT CODE: $RESULT"
@@ -42,6 +40,25 @@ if [ $RESULT -ne 0 -o -s "$ERR" ]
         echo "TRACE-ERROR OUTPUT:"
         cat "$TRACE"
     fi
+}
+
+if [ $RESULT -ne 0 -o -s "$ERR" ]
+    then
+    echo "Cronic detected failure or error output for the command:"
+    results
+fi
+
+if [ ! -z "$CRONIC_RUN_LOG" ]
+    then
+    (
+        if [ $RESULT -ne 0 -o -s "$ERR" ]
+            then
+                echo -n "Cronic detected failure or error output for the command (last run: $(date)):"
+            else
+                echo -n "Cronic ran successfully the command (last run: $(date)):"
+            fi
+        results
+    ) > "$CRONIC_RUN_LOG"
 fi
 
 rm -rf "$TMP"


### PR DESCRIPTION
Enable administrators to see what the cron outputs are both in case of successful and failed runs.